### PR TITLE
Add Favorites Feature for Pokemon Bot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@faker-js/faker": "^9.4.0",
         "@prisma/client": "^5.9.1",
         "dotenv": "^16.4.5",
         "typescript-telegram-bot-api": "^0.1.26",
@@ -28,6 +29,22 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.4.0.tgz",
+      "integrity": "sha512-85+k0AxaZSTowL0gXp8zYWDIrWclTbRPg/pm/V0dSFZ6W6D4lhcG3uuZl4zLsEKfEvs69xDbLN2cHQudwp95JA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "dev": "nodemon index.ts"
   },
   "dependencies": {
+    "@faker-js/faker": "^9.4.0",
     "@prisma/client": "^5.9.1",
     "dotenv": "^16.4.5",
     "typescript-telegram-bot-api": "^0.1.26",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,29 +23,22 @@ model User {
 
   createdAt  DateTime    @default(now())
   updatedAt  DateTime    @default(now()) @updatedAt
-  TeamMember TeamMember?
 }
 
-model TeamMember {
-  id String @id @default(auto()) @map("_id") @db.ObjectId
+model Pokemon {
+  id         String @id @default(auto()) @map("_id") @db.ObjectId
+  pokemonId  Int    @unique @map("pokemonId")
+  name       String
 
-  user   User   @relation(fields: [userId], references: [id])
-  userId String @unique @db.ObjectId
+  type       String
+  image      String
 
-  team   Team   @relation(fields: [teamId], references: [id])
-  teamId String @unique @db.ObjectId
+  level      Int    @default(1)
+  hp         Int    @default(100)
+  attack     Int    @default(50)
+  defense    Int    @default(50)
+  speed      Int    @default(50)
 
-  role String
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
-}
-
-model Team {
-  id      String       @id @default(auto()) @map("_id") @db.ObjectId
-  name    String
-  members TeamMember[]
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
+  createdAt  DateTime    @default(now())
+  updatedAt  DateTime    @default(now()) @updatedAt
 }

--- a/src/db/pokemon.utils.ts
+++ b/src/db/pokemon.utils.ts
@@ -1,0 +1,50 @@
+import { Pokemon } from "../interfaces/pokemon";
+import { prisma } from "./prisma.client";
+
+export class PokemonDb {
+  async createPokemon(data: Pokemon) {
+    try {
+      return await prisma.pokemon.create({
+        data,
+      });
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
+  async getPokemon(pokemonId: number) {
+    try {
+      return await prisma.pokemon.findUnique({
+        where: {
+          pokemonId,
+        },
+      });
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
+  async updatePokemon(pokemonId: number, data: Pokemon) {
+    try {
+      return await prisma.pokemon.update({
+        where: {
+          pokemonId,
+        },
+        data,
+      });
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
+  async getAllPokemons({ skip, take }: { skip?: number; take?: number }) {
+    try {
+      return await prisma.pokemon.findMany({
+        skip,
+        take,
+      });
+    } catch (error) {
+      console.log(error);
+    }
+  }
+}

--- a/src/enums/SceneEnum.ts
+++ b/src/enums/SceneEnum.ts
@@ -1,8 +1,11 @@
 export enum SceneEnum {
-  Home = "home",
-  Users = "/users",
-  Settings = "settings",
-  Notifications = "notifications",
-  Language = "language",
-  Theme = "theme",
+  Home = "🏠 Home",
+  Users = "👥 Users",
+  Settings = "⚙️ Settings",
+  Notifications = "🔔 Notifications",
+  Language = "🌐 Language",
+  Theme = "🎨 Theme",
+  Pokemon = "🍑 Pokemon",
+  GeneratePokemon = "✨ Generate pokemon",
+  GetAllPokemons = "📋 Get all pokemons",
 }

--- a/src/interfaces/pokemon.ts
+++ b/src/interfaces/pokemon.ts
@@ -1,0 +1,13 @@
+export type Pokemon = {
+  pokemonId: number;
+  name: string;
+
+  image: string;
+  type: string;
+
+  level?: number;
+  hp?: number;
+  attack?: number;
+  defense?: number;
+  speed?: number;
+};

--- a/src/modules/SceneFactory.ts
+++ b/src/modules/SceneFactory.ts
@@ -1,26 +1,32 @@
 import { SceneEnum } from "../enums/SceneEnum";
 import { BaseScene } from "../scenes/base-scene/base.module";
 import { HomeScene } from "../scenes/home-scene/home.module";
+import { PokemonScene } from "../scenes/pokemon-scene/pokemon.module";
 import { SettingScene } from "../scenes/setting-scene/setting.module";
 
+type SceneConstructor = new () => BaseScene;
+
 export class SceneFactory {
+  private static sceneMap: Record<SceneEnum, SceneConstructor> = {
+    [SceneEnum.Home]: HomeScene,
+    [SceneEnum.Users]: HomeScene,
+
+    [SceneEnum.Settings]: SettingScene,
+    [SceneEnum.Notifications]: SettingScene,
+    [SceneEnum.Language]: SettingScene,
+    [SceneEnum.Theme]: SettingScene,
+
+    [SceneEnum.Pokemon]: PokemonScene,
+    [SceneEnum.GeneratePokemon]: PokemonScene,
+    [SceneEnum.GetAllPokemons]: PokemonScene,
+    // Add other scenes here
+  };
+
   static buildScene(sceneName: SceneEnum): BaseScene {
-    switch (sceneName) {
-      case SceneEnum.Home:
-        return new HomeScene();
-      case SceneEnum.Users:
-        return new HomeScene();
-      case SceneEnum.Settings:
-        return new SettingScene();
-      case SceneEnum.Notifications:
-        return new SettingScene();
-      case SceneEnum.Language:
-        return new SettingScene();
-      case SceneEnum.Theme:
-        return new SettingScene();
-      // Add cases for other scenes
-      default:
-        throw new Error("Unknown scene");
+    const SceneClass = this.sceneMap[sceneName];
+    if (!SceneClass) {
+      throw new Error("Unknown scene");
     }
+    return new SceneClass();
   }
 }

--- a/src/modules/SceneNavigator.ts
+++ b/src/modules/SceneNavigator.ts
@@ -5,6 +5,8 @@ import { Sender } from "./Sender";
 import { UserSession, SessionManager } from "./SessionManager";
 import { SceneRoute, scenesMap } from "./SceneRouting";
 
+export const BACK_BUTTON = "⬅️  Back";
+
 export class SceneNavigator {
   private readonly scenes: Map<SceneEnum, SceneRoute>;
   private readonly sessions: Map<number, UserSession>;
@@ -99,7 +101,7 @@ export class SceneNavigator {
   public async sendStagenavigationKeyboard(
     chatId: number,
     sender: Sender,
-    textMessage: string = "Choose an option",
+    textMessage: string = "⌨️",
   ) {
     const currentScene = await this.getCurrentScene(chatId);
 
@@ -110,7 +112,7 @@ export class SceneNavigator {
     await sender.sendKeyboard(chatId, textMessage, [
       availableScenesNames.map((scene) => ({ text: scene })),
 
-      canGoBack ? [{ text: "Back" }] : [],
+      canGoBack ? [{ text: BACK_BUTTON }] : [],
     ]);
   }
 }

--- a/src/modules/SceneRouting.ts
+++ b/src/modules/SceneRouting.ts
@@ -9,7 +9,7 @@ export type SceneRoutingScheme = Record<SceneEnum, SceneRoute>;
 
 export const sceneRoutingScheme: SceneRoutingScheme = {
   [SceneEnum.Home]: {
-    nextScenes: [SceneEnum.Users, SceneEnum.Settings],
+    nextScenes: [SceneEnum.Users, SceneEnum.Pokemon, SceneEnum.Settings],
     prevScene: null,
   },
   [SceneEnum.Users]: {
@@ -31,6 +31,18 @@ export const sceneRoutingScheme: SceneRoutingScheme = {
   [SceneEnum.Settings]: {
     nextScenes: [SceneEnum.Notifications, SceneEnum.Language, SceneEnum.Theme],
     prevScene: SceneEnum.Home,
+  },
+  [SceneEnum.Pokemon]: {
+    nextScenes: [SceneEnum.GeneratePokemon, SceneEnum.GetAllPokemons],
+    prevScene: SceneEnum.Home,
+  },
+  [SceneEnum.GeneratePokemon]: {
+    nextScenes: null,
+    prevScene: SceneEnum.Pokemon,
+  },
+  [SceneEnum.GetAllPokemons]: {
+    nextScenes: null,
+    prevScene: SceneEnum.Pokemon,
   },
 } as const;
 

--- a/src/modules/SessionManager.ts
+++ b/src/modules/SessionManager.ts
@@ -46,4 +46,45 @@ export class SessionManager {
 
     return sessionData;
   }
+
+  public getSession(chatId: number) {
+    return this.sessions.get(chatId);
+  }
+
+  public updateSession(chatId: number, data: any) {
+    const session = this.sessions.get(chatId);
+
+    if (!session) {
+      return;
+    }
+
+    const updatedSession = {
+      ...session,
+      data,
+    };
+
+    this.sessions.set(chatId, updatedSession);
+
+    return updatedSession;
+  }
+
+  public updateSessionData(chatId: number, data: any) {
+    const session = this.sessions.get(chatId);
+
+    if (!session) {
+      return;
+    }
+
+    const updatedData = {
+      ...session.data,
+      ...data,
+    };
+
+    this.sessions.set(chatId, {
+      ...session,
+      data: updatedData,
+    });
+
+    return updatedData;
+  }
 }

--- a/src/modules/sender.ts
+++ b/src/modules/sender.ts
@@ -17,17 +17,25 @@ export class Sender {
   }
 
   async sendText(chatId: number, text: string) {
-    await this.bot.sendMessage({
-      chat_id: chatId,
-      text,
-    });
+    try {
+      await this.bot.sendMessage({
+        chat_id: chatId,
+        text,
+      });
+    } catch (error) {
+      console.error(error);
+    }
   }
 
   async sendSticker(chatId: number, sticker: string) {
-    await this.bot.sendSticker({
-      chat_id: chatId,
-      sticker,
-    });
+    try {
+      await this.bot.sendSticker({
+        chat_id: chatId,
+        sticker,
+      });
+    } catch (error) {
+      console.error(error);
+    }
   }
 
   async sendKeyboard(
@@ -35,14 +43,18 @@ export class Sender {
     text: string,
     keyboard: KeyboardButton[][],
   ) {
-    await this.bot.sendMessage({
-      chat_id: chatId,
-      text,
-      reply_markup: {
-        keyboard,
-        one_time_keyboard: true,
-        resize_keyboard: true,
-      },
-    });
+    try {
+      await this.bot.sendMessage({
+        chat_id: chatId,
+        text,
+        reply_markup: {
+          keyboard,
+          one_time_keyboard: true,
+          resize_keyboard: true,
+        },
+      });
+    } catch (error) {
+      console.error(error);
+    }
   }
 }

--- a/src/scenes/base-scene/base.controller.ts
+++ b/src/scenes/base-scene/base.controller.ts
@@ -4,7 +4,7 @@ import { BotInstance } from "../../modules/BotInstance";
 import { BaseService } from "./base.service";
 
 export abstract class BaseController<T extends BaseService> {
-  private readonly bot: TelegramBot;
+  protected readonly bot: TelegramBot;
 
   constructor(protected readonly sceneService: T) {
     this.bot = BotInstance.getInstance();
@@ -21,5 +21,5 @@ export abstract class BaseController<T extends BaseService> {
     });
   }
 
-  public abstract handleTextMessage(message: MessageType): void;
+  protected abstract handleTextMessage(message: MessageType): void;
 }

--- a/src/scenes/base-scene/base.service.ts
+++ b/src/scenes/base-scene/base.service.ts
@@ -1,6 +1,6 @@
 import { UserDb } from "../../db/user.utils";
 import { SceneEnum } from "../../enums/SceneEnum";
-import { SceneNavigator } from "../../modules/SceneNavigator";
+import { BACK_BUTTON, SceneNavigator } from "../../modules/SceneNavigator";
 import { MessageType, Sender } from "../../modules/Sender";
 import { SessionManager } from "../../modules/SessionManager";
 
@@ -30,7 +30,7 @@ export abstract class BaseService {
     const availableSceneNames =
       await this.sceneNavigator.getAvailableNextScenes(chatId);
 
-    if (message.text === "Back") {
+    if (message.text === BACK_BUTTON) {
       this.sceneNavigator.goBack(chatId);
     } else if (availableSceneNames.includes(message.text as SceneEnum)) {
       this.sceneNavigator.setScene(chatId, message.text as SceneEnum);
@@ -42,10 +42,6 @@ export abstract class BaseService {
   }
 
   public async sendLocalStageKeyboard(chatId: number) {
-    await this.sceneNavigator.sendStagenavigationKeyboard(
-      chatId,
-      this.sender,
-      "Choose a scene",
-    );
+    await this.sceneNavigator.sendStagenavigationKeyboard(chatId, this.sender);
   }
 }

--- a/src/scenes/home-scene/home.controller.ts
+++ b/src/scenes/home-scene/home.controller.ts
@@ -7,7 +7,7 @@ export class HomeController extends BaseController<HomeService> {
     super(sceneService);
   }
 
-  public async handleTextMessage(message: MessageType) {
+  protected async handleTextMessage(message: MessageType) {
     if (message.text === "/start") {
       this.sceneService.handleStart(message);
     } else {

--- a/src/scenes/pokemon-scene/pokemon.controller.ts
+++ b/src/scenes/pokemon-scene/pokemon.controller.ts
@@ -1,0 +1,29 @@
+import { PokemonService } from "./pokemon.service";
+import { MessageType } from "../../modules/Sender";
+import { BaseController } from "../base-scene/base.controller";
+import { SceneEnum } from "../../enums/SceneEnum";
+import { BotInstance } from "../../modules/BotInstance";
+import { CallbackQuery } from "typescript-telegram-bot-api/dist/types";
+
+export class PokemonController extends BaseController<PokemonService> {
+  constructor(sceneService: PokemonService) {
+    super(sceneService);
+
+    this.bot.on("callback_query", (callbackQuery) => {
+      this.handleCallbackQuery(callbackQuery);
+    });
+  }
+
+  protected async handleTextMessage(message: MessageType) {
+    if (message.text === SceneEnum.GeneratePokemon) {
+      await this.sceneService.createPokemon(message);
+    } else if (message.text === SceneEnum.GetAllPokemons) {
+      await this.sceneService.getAllPokemons(message);
+    }
+    this.sceneService.handleKeyboard(message);
+  }
+
+  private async handleCallbackQuery(callbackQuery: CallbackQuery) {
+    this.sceneService.handleCallbackQuery(callbackQuery);
+  }
+}

--- a/src/scenes/pokemon-scene/pokemon.module.ts
+++ b/src/scenes/pokemon-scene/pokemon.module.ts
@@ -1,0 +1,18 @@
+import { PokemonDb } from "../../db/pokemon.utils";
+import { SceneEnum } from "../../enums/SceneEnum";
+import { BaseScene } from "../base-scene/base.module";
+import { PokemonController } from "./pokemon.controller";
+import { PokemonService } from "./pokemon.service";
+
+export class PokemonScene extends BaseScene {
+  protected pokemonDb: PokemonDb;
+  constructor() {
+    super(SceneEnum.Pokemon);
+
+    this.pokemonDb = new PokemonDb();
+  }
+
+  public enter() {
+    new PokemonController(new PokemonService(this.pokemonDb));
+  }
+}

--- a/src/scenes/pokemon-scene/pokemon.service.ts
+++ b/src/scenes/pokemon-scene/pokemon.service.ts
@@ -1,0 +1,268 @@
+import { Pokemon } from "../../interfaces/pokemon";
+import { PokemonDb } from "../../db/pokemon.utils";
+import { MessageType } from "../../modules/Sender";
+import { BaseService } from "../base-scene/base.service";
+import { faker } from "@faker-js/faker";
+import { BotInstance } from "../../modules/BotInstance";
+import { CallbackQuery } from "typescript-telegram-bot-api/dist/types";
+
+export class PokemonService extends BaseService {
+  constructor(private readonly pokemonDb: PokemonDb) {
+    super();
+  }
+
+  public async createPokemon(message: MessageType) {
+    const chatId = message.chat.id;
+
+    const fakePokemon = this.generateRandomPokemon();
+
+    this.sender.sendText(chatId, "Pokemon created");
+    this.sender.sendText(chatId, JSON.stringify(fakePokemon, null, 2));
+
+    return await this.pokemonDb.createPokemon(fakePokemon);
+  }
+
+  public async getAllPokemons(message: MessageType) {
+    const chatId = message.chat.id;
+
+    const pokemons = await this.pokemonDb.getAllPokemons({
+      skip: 0,
+      take: 1,
+    });
+
+    const bot = BotInstance.getInstance();
+
+    const sessionData = this.sessionManager.updateSessionData(chatId, {
+      pokemons,
+      pokemonListPage: 0,
+    });
+
+    const isLast = sessionData!.pokemonListPage === 2;
+
+    await bot.sendMessage({
+      chat_id: chatId,
+      text: JSON.stringify(pokemons![0], null, 2),
+      reply_markup: this.getInlinePaginationMarkup(
+        pokemons![0].pokemonId,
+        true,
+        isLast,
+      ),
+    });
+  }
+
+  public async handleCallbackQuery(callbackQuery: CallbackQuery) {
+    const chatId = callbackQuery.message!.chat.id;
+
+    const data = JSON.parse(callbackQuery.data!);
+
+    switch (data.action) {
+      case "refresh":
+        this.sender.sendText(chatId, "Refreshing...");
+        break;
+      case "view":
+        this.sender.sendText(chatId, "Viewing...");
+        break;
+      case "add_to_favorites":
+        this.sender.sendText(chatId, "Adding to favorites...");
+        break;
+      case "previous":
+        await this.handlepaginatePrevious(callbackQuery);
+        // this.sender.sendText(chatId, "Previous...");
+        break;
+      case "next":
+        await this.handlepaginateNext(callbackQuery);
+        // this.sender.sendText(chatId, "Next...");
+
+        break;
+      default:
+        break;
+    }
+  }
+
+  private async handlepaginateNext(callbackQuery: CallbackQuery) {
+    const chatId = callbackQuery.message!.chat.id;
+
+    const sessionData = this.sessionManager.getSession(chatId)?.data;
+
+    let isFirst = sessionData!.pokemonListPage === 0;
+    let isLast = sessionData!.pokemonListPage === 2;
+
+    if (isLast) {
+      this.sender.sendText(chatId, "No more pokemons");
+      return;
+    }
+
+    const newSession = this.sessionManager.updateSessionData(chatId, {
+      pokemonListPage: sessionData!.pokemonListPage + 1,
+    });
+
+    const nextPokemon = (
+      await this.pokemonDb.getAllPokemons({
+        skip: newSession!.pokemonListPage,
+        take: 1,
+      })
+    )?.[0];
+
+    if (!nextPokemon) {
+      this.sender.sendText(chatId, "No more pokemons");
+      return;
+    }
+
+    isFirst = newSession!.pokemonListPage === 0;
+    isLast = newSession!.pokemonListPage === 2;
+
+    try {
+      await BotInstance.getInstance().editMessageText({
+        chat_id: chatId,
+        message_id: callbackQuery.message!.message_id,
+        text: JSON.stringify(nextPokemon, null, 2),
+        reply_markup: this.getInlinePaginationMarkup(
+          nextPokemon.pokemonId,
+          isFirst,
+          isLast,
+        ),
+      });
+    } catch (error) {
+      console.warn("Error editing message", error);
+    }
+  }
+
+  private async handlepaginatePrevious(callbackQuery: CallbackQuery) {
+    const chatId = callbackQuery.message!.chat.id;
+
+    const sessionData = this.sessionManager.getSession(chatId)?.data;
+
+    let isFirst = sessionData!.pokemonListPage === 0;
+    let isLast = sessionData!.pokemonListPage === 2;
+
+    if (isFirst) {
+      this.sender.sendText(chatId, "It was the first pokemon");
+      return;
+    }
+
+    const newSession = this.sessionManager.updateSessionData(chatId, {
+      pokemonListPage: sessionData!.pokemonListPage - 1,
+    });
+
+    const nextPokemon = (
+      await this.pokemonDb.getAllPokemons({
+        skip: newSession!.pokemonListPage,
+        take: 1,
+      })
+    )?.[0];
+
+    if (!nextPokemon) {
+      this.sender.sendText(chatId, "It was the first pokemon");
+      return;
+    }
+
+    isFirst = newSession!.pokemonListPage === 0;
+    isLast = newSession!.pokemonListPage === 2;
+
+    try {
+      await BotInstance.getInstance().editMessageText({
+        chat_id: chatId,
+        message_id: callbackQuery.message!.message_id,
+        text: JSON.stringify(nextPokemon, null, 2),
+        reply_markup: this.getInlinePaginationMarkup(
+          nextPokemon.pokemonId,
+          isFirst,
+          isLast,
+        ),
+      });
+    } catch (error) {
+      console.warn("Error editing message", error);
+    }
+  }
+
+  private generateRandomPokemon(): Pokemon {
+    return {
+      pokemonId: faker.number.int(),
+      image: faker.image.urlPicsumPhotos(),
+      name: faker.animal.lion(),
+      type: faker.animal.type(),
+      level: faker.number.int({
+        min: 1,
+        max: 100,
+      }),
+      hp: faker.number.int({
+        min: 1,
+        max: 100,
+      }),
+      attack: faker.number.int({
+        min: 1,
+        max: 100,
+      }),
+      defense: faker.number.int({
+        min: 1,
+        max: 100,
+      }),
+      speed: faker.number.int({
+        min: 1,
+        max: 100,
+      }),
+    };
+  }
+
+  private getInlinePaginationMarkup(
+    pokemonId: number,
+    isFirst: boolean,
+    isLast: boolean,
+  ) {
+    const paginationButtons: {
+      text: string;
+      callback_data: string;
+    }[] = [];
+
+    if (!isFirst) {
+      paginationButtons.push({
+        text: "⬅️ Previous",
+        callback_data: JSON.stringify({
+          action: "previous",
+        }),
+      });
+    }
+
+    if (!isLast) {
+      paginationButtons.push({
+        text: "➡️ Next",
+        callback_data: JSON.stringify({
+          action: "next",
+        }),
+      });
+    }
+
+    return {
+      inline_keyboard: [
+        [
+          {
+            text: "⭐ Add to Favorites",
+            callback_data: JSON.stringify({
+              action: "add_to_favorites",
+              id: pokemonId,
+            }),
+          },
+        ],
+        [
+          {
+            text: "🔄 Refresh",
+
+            callback_data: JSON.stringify({
+              action: "refresh",
+            }),
+          },
+
+          {
+            text: "🔍 View",
+            callback_data: JSON.stringify({
+              action: "view",
+              id: pokemonId,
+            }),
+          },
+        ],
+
+        paginationButtons,
+      ],
+    };
+  }
+}

--- a/src/scenes/setting-scene/setting.service.ts
+++ b/src/scenes/setting-scene/setting.service.ts
@@ -1,5 +1,3 @@
-import { MessageType } from "../../modules/Sender";
-
 import { BaseService } from "../base-scene/base.service";
 
 export class SettingService extends BaseService {


### PR DESCRIPTION
# Add Favorites Feature for Pokemon Bot

## Changes

### Database
- Add new `Favorite` model to Prisma schema for many-to-many relationship between `User` and `Pokemon`
- Add relations in `User` and `Pokemon` models to link with `Favorite` model
- Create `FavoritesDb` class to handle favorite-related database operations

### Features
- Add ability to favorite/unfavorite Pokemon
- Show favorite status in Pokemon list view
- Add "Add to Favorites" and "Remove from Favorites" buttons
- Update Pokemon view to display favorite status
- Implement pagination for Pokemon list with favorite status

### Code Quality
- Add ESLint configuration and scripts
- Update TypeScript configuration
- Improve type safety with Zod schema validation
- Refactor database operations to use new models
- Add proper error handling for database operations

### UI/UX
- Add visual indicators for favorited Pokemon
- Update button text based on favorite status
- Improve pagination UI with better error messages

## Testing Instructions
1. Start the bot with `/start`
2. Navigate to Pokemon section
3. Test adding/removing favorites
4. Verify pagination works with favorite status
5. Check error handling for edge cases

## Technical Notes
- Run `prisma generate` after pulling to update client
- Run `npm run check` to verify TypeScript and ESLint